### PR TITLE
Rename attribute macro to 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EDTest is a small set of Rust crates that make writing tests with [`rstest`](htt
 
 Crates in this workspace:
 
-- `edtest` — the user-facing crate exposing the `#[test]` attribute macro, re‑exported `rstest` helpers, `serial_test::serial`, and `static_assertions`.
+- `edtest` — the user-facing crate exposing the `#[rstest]` attribute macro, re‑exported `rstest` helpers, `serial_test::serial`, and `static_assertions`.
 - `edtest_macros` — proc‑macro implementation for `edtest`.
 - `edtest_tests` — external tests/examples for the workspace.
 
@@ -25,18 +25,18 @@ test-log = { version = "0.2", features = ["trace"] }
 serial_test = "3"
 ```
 
-Write tests as usual, using `edtest::test` in place of `rstest::rstest` and `#[test]`:
+Write tests as usual, using `edtest::rstest` in place of `rstest::rstest` and `#[test]`:
 
 ```rust
-use edtest::test;
+use edtest::rstest;
 use tracing::*;
 
-#[test]
+#[rstest]
 fn sync_test() {
 	info!("tracing output is captured");
 }
 
-#[test]
+#[rstest]
 async fn async_value_test(
 	#[values(0, 1, 2)] a: u32,
 	#[values(0, 1, 2)] b: u32,

--- a/crates/edtest/README.md
+++ b/crates/edtest/README.md
@@ -20,19 +20,19 @@ serial_test = ...
 
 tests:
 ```rust,ignore
-use edtest::test;
+use edtest::rstest;
 use tracing::*;
 
 /// Normal synchronous test.
 /// Note that `cargo test` still tries to run these concurrently!
-#[test]
+#[rstest]
 fn sync_test() {
     info!("Tracing output is captured and part of the test output");
 }
 
 /// Async tests using `tokio` are fully supported - they can even
 /// be run using `serial` (non-concurrent)
-#[test]
+#[rstest]
 #[edtest::serial]
 async fn async_value_test(
     #[values(0, 1, 2, 3, 4, 5)] a: u32,

--- a/crates/edtest/src/lib.rs
+++ b/crates/edtest/src/lib.rs
@@ -3,7 +3,7 @@
 /// Generate a test function using `rstest`. If used on a `async` function
 /// the test will use the `tokio` runtime.
 /// See the [rstest documentation](https://docs.rs/rstest/latest/rstest).
-pub use edtest_macros::test;
+pub use edtest_macros::rstest;
 
 /// Creation of test-fixtures. see the
 /// [fixture documentation](https://docs.rs/rstest/latest/rstest/attr.fixture.html).

--- a/crates/edtest/tests/uses_macro.rs
+++ b/crates/edtest/tests/uses_macro.rs
@@ -1,7 +1,7 @@
 use tracing::*;
 
 // Ensure the public macro from this crate correctly drives the runtime hooks.
-#[edtest::test]
+#[edtest::rstest]
 fn macro_smoke(#[values(1, 2)] x: u32) {
     info!(x, "macro_smoke running");
     assert!(x >= 1);

--- a/crates/edtest_macros/README.md
+++ b/crates/edtest_macros/README.md
@@ -2,6 +2,6 @@
 
 This crate contains the proc‑macro implementation backing the user‑facing `edtest` crate.
 
-You normally don't depend on this crate directly. Instead, add `edtest` as a dev‑dependency and use the `edtest::test` attribute macro in your tests.
+You normally don't depend on this crate directly. Instead, add `edtest` as a dev‑dependency and use the `edtest::rstest` attribute macro in your tests.
 
 See `crates/edtest/README.md` for usage and examples.

--- a/crates/edtest_macros/src/lib.rs
+++ b/crates/edtest_macros/src/lib.rs
@@ -5,6 +5,7 @@ mod macro_impl;
 use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
-pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn rstest(args: TokenStream, item: TokenStream) -> TokenStream {
+    // Implementation kept in macro_impl::test_attribute_impl for historical reasons.
     macro_impl::test_attribute_impl(args, item)
 }

--- a/crates/edtest_tests/src/lib.rs
+++ b/crates/edtest_tests/src/lib.rs
@@ -5,15 +5,15 @@ fn add(a: u32, b: u32) -> u32 {
 
 #[cfg(test)]
 mod test {
-    use edtest::test;
+    use edtest::rstest;
     use tracing::*;
 
-    #[test]
+    #[rstest]
     fn sync_test() {
         info!("Tracing output is captured and part of the test output");
     }
 
-    #[test]
+    #[rstest]
     async fn async_value_test(
         #[values(0, 1, 2, 3, 4, 5)] a: u32,
         #[values(0, 1, 2, 3, 4, 5)] b: u32,

--- a/examples/usage/tests/async_serial.rs
+++ b/examples/usage/tests/async_serial.rs
@@ -1,8 +1,8 @@
-use edtest::test;
+use edtest::rstest;
 use std::time::Duration;
 
 /// Async test runs on the Tokio runtime and can be marked `serial` to avoid concurrency.
-#[test]
+#[rstest]
 #[edtest::serial]
 async fn async_value_test(#[values(0, 1)] a: u32, #[values(0, 1)] b: u32) {
     let sum = edtest_example_usage::add(a, b);

--- a/examples/usage/tests/basic.rs
+++ b/examples/usage/tests/basic.rs
@@ -1,15 +1,15 @@
-use edtest::test;
+use edtest::rstest;
 use tracing::*;
 
 /// Normal synchronous test. Tracing output is captured by `test-log`.
-#[test]
+#[rstest]
 fn sync_test() {
     info!("hello from sync test");
     assert_eq!(2 + 2, 4);
 }
 
-/// Parameterized test using `rstest`'s `#[values]` via `edtest::test`.
-#[test]
+/// Parameterized test using `rstest`'s `#[values]` via `edtest::rstest`.
+#[rstest]
 fn param_test(#[values(0, 1, 2)] a: u32, #[values(3, 4)] b: u32) {
     let sum = edtest_example_usage::add(a, b);
     assert_eq!(sum, a + b);

--- a/examples/usage/tests/fixtures.rs
+++ b/examples/usage/tests/fixtures.rs
@@ -1,4 +1,4 @@
-use edtest::{fixture, test};
+use edtest::{fixture, rstest};
 
 #[fixture]
 fn base() -> u32 {
@@ -10,7 +10,7 @@ fn answer(base: u32) -> u32 {
     base + 2
 }
 
-#[test]
+#[rstest]
 fn uses_fixture(answer: u32) {
     assert_eq!(answer, 42);
 }

--- a/examples/usage/tests/logging.rs
+++ b/examples/usage/tests/logging.rs
@@ -1,9 +1,9 @@
-use edtest::test;
+use edtest::rstest;
 use tracing::{debug, error, info, span, warn, Level};
 
 /// Demonstrates capturing structured logs via `tracing`.
 /// The `test-log` integration from `edtest` ensures logs appear in test output.
-#[test]
+#[rstest]
 fn logs_are_captured() {
     let outer = span!(Level::INFO, "outer", version = %env!("CARGO_PKG_VERSION"));
     let _guard = outer.enter();


### PR DESCRIPTION
Renames the exported attribute macro from  to  to avoid clashing with the builtin . Updates re-export in , docs, examples, and tests. Closes #1.