### PR TITLE
Fix: sanitize insta suffix across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- fix(edtest): sanitize `insta` snapshot suffix across platforms (Windows/macOS/Linux) to avoid invalid filenames
+- test: add unit tests for suffix sanitizer and macro integration test using inline snapshots
+- chore: add `insta` as a dev-dependency in `edtest`
+
 ## 0.8.2 - 2026-03-16
 
 - fix: previous change to the `set_snapshot_suffix!` didn't go through!

--- a/crates/edtest/Cargo.toml
+++ b/crates/edtest/Cargo.toml
@@ -20,3 +20,4 @@ static_assertions = { workspace = true }
 
 [dev-dependencies]
 tracing = { workspace = true }
+insta = "1.31.0"

--- a/crates/edtest/src/lib.rs
+++ b/crates/edtest/src/lib.rs
@@ -26,7 +26,9 @@ pub use static_assertions::*;
 macro_rules! set_snapshot_suffix {
     ($($expr:expr),*) => {
         let mut settings = insta::Settings::clone_current();
-        settings.set_snapshot_suffix(format!($($expr,)*));
+        let raw_suffix = format!($($expr,)*);
+        let cleaned = $crate::internal::clean_snapshot_suffix(&raw_suffix);
+        settings.set_snapshot_suffix(cleaned);
         let _guard = settings.bind_to_scope();
     }
 }
@@ -37,6 +39,57 @@ pub mod internal {
     use core::sync::atomic::{AtomicUsize, Ordering};
 
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// Clean a snapshot suffix so it's safe to be used in file names across
+    /// Windows, macOS and Linux.
+    ///
+    /// Strategy:
+    /// - Keep ASCII letters and digits.
+    /// - Keep '-', '_', '.', '@', '+' as-is (commonly safe on all platforms).
+    /// - Convert whitespace and path separators ('/', '\\') to '-'.
+    /// - Replace all other characters with '_'.
+    /// - Trim trailing dots/spaces (problematic on Windows).
+    /// - Avoid reserved Windows device names by prefixing with '_'.
+    /// - If the result is empty, return "snapshot".
+    #[doc(hidden)]
+    pub fn clean_snapshot_suffix(input: &str) -> String {
+        let mut out = String::with_capacity(input.len());
+        for ch in input.chars() {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '@' | '+') {
+                out.push(ch);
+            } else if ch.is_whitespace() || ch == '/' || ch == '\\' {
+                out.push('-');
+            } else {
+                out.push('_');
+            }
+        }
+
+        // Windows doesn't like trailing dots or spaces in file names
+        while out.ends_with(['.', ' ']) {
+            out.pop();
+        }
+
+        // Avoid reserved device names on Windows
+        // https://learn.microsoft.com/windows/win32/fileio/naming-a-file
+        fn is_windows_reserved(name: &str) -> bool {
+            const RESERVED: &[&str] = &[
+                "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+                "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
+                "LPT9",
+            ];
+            RESERVED.iter().any(|&r| r.eq_ignore_ascii_case(name))
+        }
+
+        if out.is_empty() || !out.chars().any(|c| c.is_ascii_alphanumeric()) {
+            return "snapshot".to_string();
+        }
+
+        if is_windows_reserved(&out) {
+            return format!("_{}", out);
+        }
+
+        out
+    }
 
     // Tiny side effects to ensure coverage sees executed regions and prevent full optimization.
     pub fn on_test_enter(name: &str) {
@@ -75,5 +128,21 @@ mod tests {
         crate::internal::on_test_enter("sample");
         let _g = crate::TestGuard::new();
         crate::internal::on_test_exit();
+    }
+
+    #[test]
+    fn cleans_suffix_general() {
+        use crate::internal::clean_snapshot_suffix as clean;
+        // Mix of problem characters including separators and invalid Windows chars
+        let s = "a/b\\c:d*e?f|g<h>i\"j k.";
+        assert_eq!(clean(s), "a-b-c_d_e_f_g_h_i_j-k");
+    }
+
+    #[test]
+    fn cleans_suffix_reserved_and_empty() {
+        use crate::internal::clean_snapshot_suffix as clean;
+        assert_eq!(clean("CON"), "_CON");
+        assert_eq!(clean("con"), "_con");
+        assert_eq!(clean("   \t\n"), "snapshot");
     }
 }

--- a/crates/edtest/tests/uses_macro.rs
+++ b/crates/edtest/tests/uses_macro.rs
@@ -6,3 +6,22 @@ fn macro_smoke(#[values(1, 2)] x: u32) {
     info!(x, "macro_smoke running");
     assert!(x >= 1);
 }
+
+// Ensure the snapshot suffix is cleaned by the macro so paths are valid on all OSes.
+#[test]
+fn macro_suffix_cleaned() {
+    // Contains path separators, Windows-forbidden characters, quotes, and trailing dot/space
+    let raw = "a/b\\c:d*e?f|g<h>i\"j k. ";
+    let expected = edtest::internal::clean_snapshot_suffix(raw);
+
+    // This should set a cleaned suffix under the hood without panicking or producing invalid paths
+    edtest::set_snapshot_suffix!("{}", raw);
+
+    // Taking an inline snapshot exercises insta name/path generation while avoiding filesystem writes.
+    // If suffix cleaning is wrong, insta can error on some platforms. Inline keeps the test deterministic.
+    let value = "ok";
+    insta::assert_snapshot!(value, @"ok");
+
+    // Also assert the sanitizer behavior directly for determinism across platforms.
+    assert_eq!(expected, "a-b-c_d_e_f_g_h_i_j-k.-");
+}


### PR DESCRIPTION
Addresses #11: sanitize snapshot suffix to ensure valid paths on Windows, macOS and Linux. Adds tests and updates CHANGELOG.